### PR TITLE
switch to fixed chromium version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,78 @@ FROM node:lts-stretch AS builder
 LABEL MAINTAINER="KML VISION, devops@kmlvision.com"
 
 COPY --from=yaml-reader /usr/bin/yq /usr/bin/yq
-# install chromium and export the binary file for testing
-RUN apt-get update -qq && \
-    apt-get install -qq -y --no-install-recommends chromium gettext && \
-    apt-get clean && \
+
+# install chromium deps
+RUN apt update -qq && \
+    apt install -qq -y \
+	libasound2 \
+	libatk1.0-0 \
+	libatk-bridge2.0-0 \
+	libgtk-3-0 \
+	libatomic1 \
+	libatspi2.0-0 \
+	libavcodec57 \
+	libavutil55 \
+	libc6 \
+	libcairo2 \
+	libcups2 \
+	libdbus-1-3 \
+	libdrm2 \
+	libevent-2.0-5 \
+	libexpat1 \
+	libflac8 \
+	libfontconfig1 \
+	libfreetype6 \
+	libgcc1 \
+	libgdk-pixbuf2.0-0 \
+	libglib2.0-0 \
+	libgtk2.0-0 \
+	libicu57 \
+	libjpeg62-turbo \
+	libminizip1 \
+	libnspr4 \
+	libnss3 \
+	libopenjp2-7 \
+	libopus0 \
+	libpango-1.0-0 \
+	libpangocairo-1.0-0 \
+	libpangoft2-1.0-0 \
+	libpci3 \
+	libpng16-16 \
+	libpulse0 \
+	libre2-3 \
+	libsnappy1v5 \
+	libstdc++6 \
+	libvpx4 \
+	libwebp6 \
+	libwebpdemux2 \
+	libwebpmux2 \
+	libx11-6 \
+	libx11-xcb1 \
+	libxcb1 \
+	libxcomposite1 \
+	libxcursor1 \
+	libxdamage1 \
+	libxext6 \
+	libxfixes3 \
+	libxi6 \
+	libxml2 \
+	libxrandr2 \
+	libxrender1 \
+	libxslt1.1 \
+	libxss1 \
+	libxtst6 \
+	x11-utils \
+	xdg-utils \
+	zlib1g \
+    && apt clean && \
     rm -rf /var/cache/apt/archives/
-ENV CHROME_BIN=chromium
+
+# install specific chromium version and export the binary file for testing
+# for chromium updates see README.md
+ENV CHROMIUM_DOWNLOAD_LOCATION=https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Linux_x64%2F664981%2Fchrome-linux.zip?generation=1559265534319509&alt=media
+ENV CHROMIUM_VERSION=76.0.3809.100
+ENV CHROME_BIN=/opt/chrome-linux/chrome
+RUN wget -O chromium-latest-stable.zip "$CHROMIUM_DOWNLOAD_LOCATION" && \
+	unzip -d /opt chromium-latest-stable.zip && \
+	ln -s "$CHROME_BIN" /usr/bin/chromium

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # node-chromium
 Base image for unit/e2e testing node applications.
+
+## ensuring chromium version
+
+Downloading old builds of Chrome / Chromium (see [Project Chromium](https://www.chromium.org/getting-involved/download-chromium))
+
+Let's say you want a build of Chrome 44 for debugging purposes. Google does not offer old builds as they do not have up-to-date security fixes.
+
+However, you can get a build of Chromium 44.x which should mostly match the stable release. Here's how you find it:
+
+Look in https://googlechromereleases.blogspot.com/search/label/Stable%20updates for the last time "44." was mentioned.
+Loop up that version history ("44.0.2403.157") in the Position Lookup
+In this case it returns a base position of "330231". This is the commit of where the 44 release was branched, back in May 2015. (see footnote)
+Open the continuous builds archive
+Click through on your platform (Linux/Mac/Win)
+Paste "330231" into the filter field at the top and wait for all the results to XHR in.
+Eventually I get a perfect hit: https://commondatastorage.googleapis.com/chromium-browser-snapshots/index.html?prefix=Mac/330231/ -- Sometimes you may have to decrement the commit number until you find one.
+Download and run!
+footnote: As this build was made at 44 branch point, it does not have any commits merged in while in beta. Typically that's OK, but if you need a true build of "44.0.2403.x" then you'll need to build Chromium from the 2403 branch. Some PortableApps/PortableChromium sites offer binaries like this, due to security concerns, the Chrome team does not recommend running them.

--- a/google-chrome.list
+++ b/google-chrome.list
@@ -1,0 +1,3 @@
+### THIS FILE IS AUTOMATICALLY CONFIGURED ###
+# You may comment out this entry, but any other modifications may be lost.
+deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main


### PR DESCRIPTION
@pkainz i suggest to switch from relying on the debian package version of chrome to install a fixed version from chromium build archive (see README.md)
we could easily tag the kmlvision/node-chromium docker image with the right version and use a fixed version in our ci scripts (which would make version management for chrome based testing much easier)